### PR TITLE
Simplification of insertion & pruning code

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1550,7 +1550,7 @@ impl_runtime_apis! {
 		Block,
 		mmr::Hash,
 	> for Runtime {
-		fn generate_proof(leaf_index: u64)
+		fn generate_proof(leaf_index: pallet_mmr::primitives::LeafIndex)
 			-> Result<(mmr::EncodableOpaqueLeaf, mmr::Proof<mmr::Hash>), mmr::Error>
 		{
 			Mmr::generate_proof(leaf_index)

--- a/frame/merkle-mountain-range/primitives/src/lib.rs
+++ b/frame/merkle-mountain-range/primitives/src/lib.rs
@@ -26,8 +26,15 @@ use sp_std::fmt;
 #[cfg(not(feature = "std"))]
 use sp_std::prelude::Vec;
 
-/// Node index type.
+/// A type to describe node position in the MMR (node index).
 pub type NodeIndex = u64;
+
+/// A type to describe leaf position in the MMR.
+///
+/// Note this is different from [`NodeIndex`], which can be applied to
+/// both leafs and inner nodes. Leafs will always have consecutive `LeafIndex`,
+/// but might be actually at different positions in the MMR `NodeIndex`.
+pub type LeafIndex = u64;
 
 /// A provider of the MMR's leaf data.
 pub trait LeafDataProvider {
@@ -278,7 +285,7 @@ impl_leaf_data_for_tuple!(A:0, B:1, C:2, D:3, E:4);
 #[derive(codec::Encode, codec::Decode, RuntimeDebug, Clone, PartialEq, Eq)]
 pub struct Proof<Hash> {
 	/// The index of the leaf the proof is for.
-	pub leaf_index: NodeIndex,
+	pub leaf_index: LeafIndex,
 	/// Number of leaves in MMR, when the proof was generated.
 	pub leaf_count: NodeIndex,
 	/// Proof elements (hashes of siblings of inner nodes on the path to the leaf).
@@ -405,7 +412,7 @@ sp_api::decl_runtime_apis! {
 	/// API to interact with MMR pallet.
 	pub trait MmrApi<Hash: codec::Codec> {
 		/// Generate MMR proof for a leaf under given index.
-		fn generate_proof(leaf_index: NodeIndex) -> Result<(EncodableOpaqueLeaf, Proof<Hash>), Error>;
+		fn generate_proof(leaf_index: LeafIndex) -> Result<(EncodableOpaqueLeaf, Proof<Hash>), Error>;
 
 		/// Verify MMR proof against on-chain MMR.
 		///

--- a/frame/merkle-mountain-range/rpc/src/lib.rs
+++ b/frame/merkle-mountain-range/rpc/src/lib.rs
@@ -32,7 +32,7 @@ use sp_blockchain::HeaderBackend;
 use sp_core::Bytes;
 use sp_runtime::{generic::BlockId, traits::Block as BlockT};
 
-pub use pallet_mmr_primitives::{MmrApi as MmrRuntimeApi, NodeIndex};
+pub use pallet_mmr_primitives::{MmrApi as MmrRuntimeApi, LeafIndex};
 
 /// Retrieved MMR leaf and its proof.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -71,7 +71,7 @@ pub trait MmrApi<BlockHash> {
 	#[rpc(name = "mmr_generateProof")]
 	fn generate_proof(
 		&self,
-		leaf_index: NodeIndex,
+		leaf_index: LeafIndex,
 		at: Option<BlockHash>,
 	) -> Result<LeafProof<BlockHash>>;
 }
@@ -98,7 +98,7 @@ where
 {
 	fn generate_proof(
 		&self,
-		leaf_index: NodeIndex,
+		leaf_index: LeafIndex,
 		at: Option<<Block as BlockT>::Hash>,
 	) -> Result<LeafProof<<Block as BlockT>::Hash>> {
 		let api = self.client.runtime_api();

--- a/frame/merkle-mountain-range/src/mmr/utils.rs
+++ b/frame/merkle-mountain-range/src/mmr/utils.rs
@@ -17,16 +17,16 @@
 
 //! Merkle Mountain Range utilities.
 
-use crate::primitives::NodeIndex;
+use crate::primitives::{NodeIndex, LeafIndex};
 
 /// MMR nodes & size -related utilities.
 pub struct NodesUtils {
-	no_of_leaves: NodeIndex,
+	no_of_leaves: LeafIndex,
 }
 
 impl NodesUtils {
 	/// Create new instance of MMR nodes utilities for given number of leaves.
-	pub fn new(no_of_leaves: NodeIndex) -> Self {
+	pub fn new(no_of_leaves: LeafIndex) -> Self {
 		Self { no_of_leaves }
 	}
 
@@ -36,7 +36,7 @@ impl NodesUtils {
 	}
 
 	/// Return the number of leaves in the MMR.
-	pub fn number_of_leaves(&self) -> NodeIndex {
+	pub fn number_of_leaves(&self) -> LeafIndex {
 		self.no_of_leaves
 	}
 


### PR DESCRIPTION
Related: https://github.com/paritytech/substrate/pull/9700/files

Please take a look at my take on `peaks` and `elems` processing loop.
This approach avoids unnecessary allocations and extra iterations by leveraging iterators

Also using `NodeIndex` in context of `leaf_indices` is confusing, hence I've introduced an extra type.

CC @adoerr